### PR TITLE
Copy files with permissions expected by goss tests

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,9 +44,9 @@ RUN \
   jq \
   util-linux
 
-COPY ./script/backup.sh  /app/backup.sh
-COPY ./script/restore.sh /app/restore.sh
-COPY ./entrypoint.sh     /entrypoint.sh
+COPY --chmod=755 ./script/backup.sh  /app/backup.sh
+COPY --chmod=755 ./script/restore.sh /app/restore.sh
+COPY --chmod=755 ./entrypoint.sh     /entrypoint.sh
 
 COPY --from=kopia      /app/kopia             /usr/local/bin/kopia
 COPY --from=flux-cli   /usr/local/bin/flux    /usr/local/bin/flux


### PR DESCRIPTION
Copy files with permissions expected by goss tests, as my local permissions are 775 which is not expected.

```
$ goss test
...
Failures/Skipped:

File: /app/backup.sh: mode:
Expected
    <string>: 0775
to equal
    <string>: 0755

File: /app/restore.sh: mode:
Expected
    <string>: 0775
to equal
    <string>: 0755

Total Duration: 0.000s
Count: 12, Failed: 2, Skipped: 0
Retrying in 2s (elapsed/timeout time: 8.007s/15s)
```